### PR TITLE
fix(i18n): french ban-lu name

### DIFF
--- a/SilenceBanLu.lua
+++ b/SilenceBanLu.lua
@@ -3,6 +3,17 @@ local addonName = ...
 -- globals
 local CreateFrame, C_ChatBubbles, UnitClassBase, C_AddOns, UnitName, MuteSoundFile, ChatFrame_AddMessageEventFilter, WorldFrame = CreateFrame, C_ChatBubbles, UnitClassBase, C_AddOns, UnitName, MuteSoundFile, ChatFrame_AddMessageEventFilter, WorldFrame
 
+-- localization
+local authorLocalization = {
+	[0] = "Ban-Lu",
+	["frFR"] = "Ban Lu"
+}
+local getAuthorName = function()
+	local locale = GetLocale()
+	local name = authorLocalization[locale] or authorLocalization[0]
+	return name
+end
+
 -- disable the addon for non-Monk players
 if UnitClassBase("player") ~= "MONK" then
 	C_AddOns.DisableAddOn(addonName, UnitName("player"))
@@ -53,12 +64,12 @@ local function checkChatBubble(chatBubble)
 	-- only Ban-Lu's messages will be in this table (author will always be Ban-Lu)
 	local author = banLuMessages[message]
 
-	if author == "Ban-Lu" and not chatBubble.banlu then
+	if author == getAuthorName() and not chatBubble.banlu then
 		-- this bubble isn't hidden already, and Ban-Lu said the line contained within, hide the frame
 		local chatBubbleFrame = select(1, chatBubble:GetChildren())
 		chatBubbleFrame:Hide()
 		chatBubble.banlu = true
-	elseif author ~= "Ban-Lu" and chatBubble.banlu then
+	elseif author ~= getAuthorName() and chatBubble.banlu then
 		-- the author is not Ban-Lu but the frame is hidden, show the frame
 		local chatBubbleFrame = select(1, chatBubble:GetChildren())
 		chatBubbleFrame:Show()
@@ -98,7 +109,7 @@ end)
 
 -- filter Ban-Lu's spam from chat, and any chat bubbles he might produce
 local function maybeBanLuFilter(_, _, message, author, ...)
-	if author == "Ban-Lu" then
+	if author == getAuthorName() then
 		banLuMessages[message] = author
 		BubbleWatcher:Show()
 		-- returning true filters the message from chat


### PR DESCRIPTION
### Issue

Ban-Lu isn't muted when running World of Warcraft in some other langages.
It is due to the fact that Blizzard translators didn't spell its name the same across langages. In english and many others it is `Ban-Lu`, but in french it is `Ban Lu` (no dash):
![Capture_decran_2025-05-14_150536](https://github.com/user-attachments/assets/1d26db4c-e211-4cba-b074-9b06d522e65e)
For now I fix it by editing the lua file in my addons files, with the french Ban-Lu name.

### Fix proposal

It would be nice to have the mount name localized.
I've written this so it can be populated with more locale-specific names. If no specific, it falls back to `Ban-Lu`, the english version.

### Additionnal

Also, the name of the mount seems to match Ban-Lu's name in chat: ["BanLu" on WowHead french](https://www.wowhead.com/fr/item=142225)
So theorically, even if I cannot test it, the [portuguese](https://www.wowhead.com/pt/item=142225) and [mexican spanish](https://www.wowhead.com/mx/item=142225) **should** be written `Ban-lu` (lower case `L`) and non-latin like [korean](https://www.wowhead.com/ko/item=142225) should have a specific name as well.

---

Thanks for considering this fix for non-english players. Feel free to write it your way and close this PR if you prefer.

And thanks anyway for this simple yet very appreciated addon!